### PR TITLE
fix: replace all references to notebooklm.google.com to notebook.google.com

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -28,9 +28,9 @@ NotebookLM Citation Mapper is a Chrome extension that enhances your experience w
 - **What we access:** Permission to write text to your system clipboard
 - **What we don't do:** We never read from your clipboard or access clipboard history
 
-#### `host_permissions` for `https://notebooklm.google.com/*`
+#### `host_permissions` for `https://notebook.google.com/*`
 - **Why we need it:** To function specifically on Google NotebookLM pages
-- **What we access:** Only pages on notebooklm.google.com domain
+- **What we access:** Only pages on notebook.google.com domain
 - **What we don't do:** We never access any other websites or Google services
 
 ## Local Processing

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A Chrome extension that automatically maps citation numbers to source filenames 
 
 ## Usage
 
-1. Navigate to [notebooklm.google.com](https://notebooklm.google.com)
+1. Navigate to [notebook.google.com](https://notebook.google.com)
 
 2. The extension will automatically:
    - Scan for citations in the current notebook

--- a/extension/README.md
+++ b/extension/README.md
@@ -39,7 +39,7 @@ When you copy text from NotebookLM's chat interface, the citation numbers (like 
 
 ### Basic Usage
 
-1. Navigate to Google NotebookLM (https://notebooklm.google.com)
+1. Navigate to Google NotebookLM (https://notebook.google.com)
 2. Open a notebook and start a chat
 3. Click the extension icon to see current citation mappings
 4. Copy text from the chat - citations will be automatically included
@@ -71,7 +71,7 @@ All citation processing happens locally in your browser. No data is sent to exte
 
 - **Manifest Version**: 3
 - **Permissions**: activeTab, clipboardWrite, storage
-- **Host Permissions**: https://notebooklm.google.com/*
+- **Host Permissions**: https://notebook.google.com/*
 - **Background**: Service worker for state management
 - **Content Scripts**: Injected at document_idle
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -9,7 +9,7 @@ chrome.runtime.onInstalled.addListener(() => {
     id: 'notebooklm-citation-mapper',
     title: 'Show Citation Mappings',
     contexts: ['page'],
-    documentUrlPatterns: ['https://notebooklm.google.com/*']
+    documentUrlPatterns: ['https://notebook.google.com/*']
   });
 });
 
@@ -23,7 +23,7 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 
 // Listen for tab updates to inject content script if needed
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status === 'complete' && tab.url && tab.url.includes('notebooklm.google.com')) {
+  if (changeInfo.status === 'complete' && tab.url && tab.url.includes('notebook.google.com')) {
     // Content script should be automatically injected via manifest
     // This is just a fallback if needed
     chrome.scripting.executeScript({

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,11 +9,11 @@
     "storage"
   ],
   "host_permissions": [
-    "https://notebooklm.google.com/*"
+    "https://notebook.google.com/*"
   ],
   "content_scripts": [
     {
-      "matches": ["https://notebooklm.google.com/*"],
+      "matches": ["https://notebook.google.com/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
     }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -155,7 +155,7 @@ document.addEventListener('DOMContentLoaded', function() {
     let isNotebookLM = false;
     try {
       const url = new URL(currentTab.url);
-      isNotebookLM = url.hostname === 'notebooklm.google.com';
+      isNotebookLM = url.hostname === 'notebook.google.com';
     } catch (e) {
       isNotebookLM = false;
     }
@@ -163,7 +163,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (!isNotebookLM) {
       statusText.textContent = 'Please open Google NotebookLM';
       statusText.style.color = '#d93025';
-      mappingsContainer.innerHTML = '<div class="loading">This extension only works on notebooklm.google.com</div>';
+      mappingsContainer.innerHTML = '<div class="loading">This extension only works on notebook.google.com</div>';
       copyBtn.disabled = true;
       copyChatBtn.disabled = true;
       copyRichBtn.disabled = true;


### PR DESCRIPTION
Hi!
I just saw your extension and would love to use it, but since google renamed their service to notebook.google.com, the plugin stopped working. I have manually changed all references from notebooklm to notebook and the extension appear to be working again! :-)